### PR TITLE
Fix missing e in ActiveRecord::Base

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,4 +1,4 @@
-class Authorization < ActiveRecord::Bas
+class Authorization < ActiveRecord::Base
   has_one :person
 
   before_create do


### PR DESCRIPTION
Notice while working on another patch that the `e` was missing from the end of `ActiveRecord::Base`.
